### PR TITLE
fix(placement): scroll Y axis menu offset

### DIFF
--- a/ContextMenu.js
+++ b/ContextMenu.js
@@ -156,8 +156,9 @@ function useContextMenu(props = {}) {
       left = windowWidth - menuWidth;
     }
 
-    if (top + menuHeight > windowHeight) {
-      top = windowHeight - menuHeight;
+    const screenBottom = window.pageYOffset + windowHeight;
+    if (top + menuHeight > screenBottom) {
+      top = screenBottom - menuHeight;
     }
 
     return { left, top };

--- a/index.js
+++ b/index.js
@@ -241,8 +241,10 @@ function useContextMenu() {
       left = windowWidth - menuWidth;
     }
 
-    if (top + menuHeight > windowHeight) {
-      top = windowHeight - menuHeight;
+    var screenBottom = window.pageYOffset + windowHeight;
+
+    if (top + menuHeight > screenBottom) {
+      top = screenBottom - menuHeight;
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextmenu",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Menu was displayed out of screen when popping menu on the bottom of the page (on a long webpage with Y scroll).

Tested on Chrome 100+